### PR TITLE
グループ機能の実装

### DIFF
--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      = f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__action-btn'


### PR DESCRIPTION
#what
コントローラ、モデルを作成する
ルーティングを設定する
該当するアクションをコントローラに定義する
素材をダウンロードする
アクセス先のビューを作成する
グループ作成機能を実装する
作成したグループをサイドバーに表示する
グループ編集機能を実装する
ルートパスを変更する
#why
ChatSpaceにグループ機能を追加し、
メッセージをやり取りするためのグループを作れるようする。